### PR TITLE
IpAddr needed to validate sockaddr * to avoid segv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ lib: arlib
 
 arlib: lib/libtcanetpp.a
 
-solib: libtcanetpp.so.1.2.2
+solib: libtcanetpp.so.1.2.3
 
 libtcapt: lib/libtcapt.a
 
@@ -84,7 +84,7 @@ lib/libtcanetpp.a: ${OBJS}
 	$(make-lib-rule)
 	@echo
 
-libtcanetpp.so.1.2.2: ${OBJS}
+libtcanetpp.so.1.2.3: ${OBJS}
 	( $(MKDIR) lib )
 	( $(RM) $@ lib/libtcanetpp.so )
 	$(make-so-rule)

--- a/include/CircularBuffer.h
+++ b/include/CircularBuffer.h
@@ -64,6 +64,7 @@ class BufferException : public Exception {
     BufferException ( const std::string & s_err )
         : Exception(s_err)
     {}
+    virtual ~BufferException() {}
 };
 
 

--- a/include/Exception.hpp
+++ b/include/Exception.hpp
@@ -38,7 +38,9 @@ extern "C" {
 namespace tcanetpp {
 
 
-/**  Base Exception class used and thrown by the tcanetpp library. */
+/**  Base Exception class used and thrown by the tcanetpp library
+  *  (as infrequently as possible).
+ **/
 class Exception : public std::runtime_error {
 
 public:
@@ -47,7 +49,7 @@ public:
         : std::runtime_error(errstr)
     {}
 
-    virtual ~Exception() throw() {}
+    virtual ~Exception() {}
 
     virtual void printErr() const
     {

--- a/include/IpAddr.h
+++ b/include/IpAddr.h
@@ -45,7 +45,7 @@ typedef std::set<IpAddr>     IpAddrSet;
 typedef std::vector<IpAddr>  IpAddrList;
 
 
-/**  Provides seamless interaction with an underlying sockaddr
+/**  Provides seamless interaction with the underlying sockaddr
   *  supporting both IPV4 and IPV6 addresses.
  */
 class IpAddr {
@@ -57,8 +57,7 @@ class IpAddr {
     IpAddr ( const ipv4addr_t & addr, uint8_t mb = 32 );
     IpAddr ( const ipv6addr_t & addr, uint8_t mb = 64 );
     IpAddr ( const IpAddr & ipaddr );
-
-    virtual ~IpAddr();
+    ~IpAddr();
 
     IpAddr&             operator=    ( const IpAddr & ipaddr );
     bool                operator==   ( const IpAddr & ipaddr ) const;
@@ -123,12 +122,15 @@ class IpAddr {
 
     static uint32_t     RandomValue  ( double     range );
     static IpAddr       RandomAddr   ( IpAddr   & agg );
-    static ipv4addr_t   RandomPrefix ( ipv4addr_t addr, uint8_t mb );
+    static ipv4addr_t   RandomPrefix ( ipv4addr_t addr,
+                                       uint8_t    mb );
 
-    static bool         DeAggregate  ( const IpAddr & pfx, uint8_t mb,
+    static bool         DeAggregate  ( const IpAddr & pfx,
+                                       uint8_t        mb,
                                        IpAddrList   & v );
 
-    static int          GetCidrRange ( uint8_t mb, uint8_t * subnet = NULL );
+    static int          GetCidrRange ( uint8_t   mb,
+                                       uint8_t * subnet = NULL );
     static int          GetIpv6Range ( uint8_t mb );
 
 
@@ -139,6 +141,5 @@ class IpAddr {
 };
 
 } // namespace
-
 
 #endif // _TCANETPP_IPADDR_H_

--- a/include/StringUtils.h
+++ b/include/StringUtils.h
@@ -203,7 +203,8 @@ class StringUtils {
 
 
     template<typename T>
-    static inline std::wstring ToWString   ( const T & a )
+    static inline
+    std::wstring         ToWString        ( const T & a )
     {
         std::wstringstream  stream;
         stream << a;
@@ -211,7 +212,7 @@ class StringUtils {
     }
 
     template<typename T>
-    static inline  T     FromWString       ( const std::wstring & wstr )
+    static inline  T     FromWString      ( const std::wstring & wstr )
     {
         T target = T();
         std::wstringstream stream(wstr);
@@ -235,6 +236,7 @@ class StringUtils {
         }
     }
 
+
     template< typename OutputIterator_ >
     static inline void   Split            ( const std::wstring  & str,
                                             const std::wstring  & delimiter,
@@ -249,6 +251,7 @@ class StringUtils {
             begin   = end;
         }
     }
+
 #endif  // TCANET_WIDECHAR
 
 }; // class StringUtils

--- a/include/Thread.h
+++ b/include/Thread.h
@@ -50,6 +50,7 @@ class ThreadException : public Exception {
   public:
     ThreadException ( const std::string & s_err )
         : Exception(s_err) {}
+    virtual ~ThreadException() {}
 };
 
 

--- a/include/tcanetpp_config.h
+++ b/include/tcanetpp_config.h
@@ -29,7 +29,7 @@
 
 
 #define TCANETPP_VERSION_TS  "02.14.2018"
-#define TCANETPP_VERSION     "1.2.2"
+#define TCANETPP_VERSION     "1.2.3"
 
 // widechar support
 // comment to disable

--- a/src/IpAddr.cpp
+++ b/src/IpAddr.cpp
@@ -78,21 +78,26 @@ IpAddr::IpAddr ( const ipv4addr_t & addr, uint8_t mb )
 IpAddr::IpAddr ( const sockaddr_t * sa )
     : _mb(0)
 {
-    sockaddr_t * s = (sockaddr_t*) sa;
-
-    ::memcpy(&_saddr, s, sizeof(sockaddr_t));
-
-    switch ( s->ss_family )
+    if ( sa != NULL )
     {
-        case AF_INET:
-            _mb  = 32;
-            break;
-        case AF_INET6:
-            _mb  = 64;
-            break;
-        default:
-            _mb  = 0;
-            break;
+        sockaddr_t * s = (sockaddr_t*) sa;
+
+        ::memcpy(&_saddr, s, sizeof(sockaddr_t));
+
+        switch ( s->ss_family )
+        {
+            case AF_INET:
+                _mb  = 32;
+                break;
+            case AF_INET6:
+                _mb  = 64;
+                break;
+            default:
+                _mb  = 0;
+                break;
+        }
+    } else {
+        ::memset(&_saddr, 0, sizeof(sockaddr_t));
     }
 }
 
@@ -275,8 +280,10 @@ IpAddr::toString() const
     if ( this->ipv4() )
         ipstr = IpAddr::ntop(this->getAddr4());
     else
-        AddrInfo::GetNameInfo((const sockaddr*)&_saddr, sizeof(sockaddr_t), ipstr, NI_NUMERICHOST);
-
+        AddrInfo::GetNameInfo((const sockaddr*) &_saddr,
+                               sizeof(sockaddr_t),
+                               ipstr,
+                               NI_NUMERICHOST);
     return ipstr;
 }
 
@@ -284,11 +291,11 @@ std::string
 IpAddr::toPrefixString() const
 {
     std::string  ipstr;
-
     ipstr = IpAddr::ToPrefixStr(*this);
-
     return ipstr;
 }
+
+//-------------------------------------------------------------------//
 
 /** Returns a boolean indicating whether the IP Address is
   * a loopback address i
@@ -301,6 +308,8 @@ IpAddr::isLoopback() const
 
     return IpAddr::IsLoopback(this->getAddr6());
 }
+
+//-------------------------------------------------------------------//
 
 /**  Method for returning an IP cidr(prefix_t) structure.
  **/
@@ -325,7 +334,6 @@ IpAddr::getPrefixType() const
 
 //-------------------------------------------------------------------//
 //  Static Functions
-//-------------------------------------------------------------------//
 
 
 bool


### PR DESCRIPTION
missing virtual destructor in exception